### PR TITLE
Update transcode pack download URL

### DIFF
--- a/setup/root/install.sh
+++ b/setup/root/install.sh
@@ -17,7 +17,7 @@ mkdir -p /opt/madsonic/transcode
 curl -o /opt/madsonic/madsonic.zip -L http://www.madsonic.org/download/6.0/20160109_madsonic-6.0.7860-standalone.zip
 
 # download madsonic transcode
-curl -o /opt/madsonic/transcode/transcode.zip -L http://www.madsonic.org/download/transcode/20160109_madsonic-transcode-windows-x64.zip
+curl -o /opt/madsonic/transcode/transcode.zip -L http://madsonic.org/download/transcode/20160505_madsonic-transcode-linux-x64.zip
 
 # unzip madsonic and transcode
 unzip /opt/madsonic/madsonic.zip -d /opt/madsonic


### PR DESCRIPTION
Right now the script is downloading the Windows transcode pack instead of the Linux one, which means they can't be run in the container. This PR changes the transcoding download link to the correct one.